### PR TITLE
Add enabled commands to config

### DIFF
--- a/src/main/java/me/chaseoes/tf2/listeners/PlayerCommandPreprocessListener.java
+++ b/src/main/java/me/chaseoes/tf2/listeners/PlayerCommandPreprocessListener.java
@@ -1,6 +1,7 @@
 package me.chaseoes.tf2.listeners;
 
 import me.chaseoes.tf2.GameUtilities;
+import me.chaseoes.tf2.TF2;
 import me.chaseoes.tf2.utilities.Localizer;
 
 import org.bukkit.event.EventHandler;
@@ -12,10 +13,17 @@ public class PlayerCommandPreprocessListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onCommand(PlayerCommandPreprocessEvent event) {
-        if (GameUtilities.getUtilities().getGamePlayer(event.getPlayer()).isIngame() && !event.getMessage().startsWith("/tf2") && !event.getPlayer().hasPermission("tf2.create")) {
+        if (GameUtilities.getUtilities().getGamePlayer(event.getPlayer()).isIngame() && !canUseCommand(event.getMessage()) && !event.getPlayer().hasPermission("tf2.create")) {
             event.setCancelled(true);
             event.getPlayer().sendMessage(Localizer.getLocalizer().loadPrefixedMessage("CANT-USE-COMMANDS-INGAME"));
         }
     }
-
+    
+    public boolean canUseCommand (String command){
+    	for (String itemInList : TF2.getInstance().getConfig().getStringList("enabled-ingame-commands")){
+    		if (command.startsWith(itemInList))
+    			return true;
+    	}
+    	return false;
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,6 +23,10 @@ run-commands-on-win:
   enabled: false
   commands:
   - give %player diamond 1
+enabled-ingame-commands:
+  - /tf2
+  - /msg
+  - /r
 killsound:
   sound: CAT_HIT
   volume: 20


### PR DESCRIPTION
This is to prevent giving tf2.create permission to moderators. Which they need to be able to mute people without leaving the tf2 arena every single time. 

This is a fix for this problem.

Just for the default config, I added /msg and /r so normal members can communicate with each other.
